### PR TITLE
Add more links and remove reviewable.k8s.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 ## Workflow
 
 - [Gubernator Dashboard - k8s.reviews](https://k8s-gubernator.appspot.com/pr)
-- [reviewable.kubernetes.io](https://reviewable.kubernetes.io/reviews#-)
 - [Submit Queue](https://submit-queue.k8s.io)
-- [Bot commands](https://github.com/kubernetes/test-infra/blob/master/commands.md)
+- [Bot commands](https://prow.k8s.io/command-help)
+- [GitHub labels](https://go.k8s.io/github-labels)
 - [Release Buckets](http://gcsweb.k8s.io/gcs/kubernetes-release/)
 - [Developer Guide]
   - [Cherry Picking Guide](https://github.com/kubernetes/community/blob/master/contributors/devel/cherry-picks.md) - [Queue](http://cherrypick.k8s.io/#/queue)
@@ -31,8 +31,11 @@
 ## Tests
 
 - [What is currently testing](https://prow.k8s.io/)
-- [Aggregated Failures](https://storage.googleapis.com/k8s-gubernator/triage/index.html)
-- [Test Grid](https://k8s-testgrid.appspot.com/)
+- [Aggregated Failures](https://go.k8s.io/triage)
+- [Test Grid](https://testgrid.k8s.io)
+- [Test Health](https://go.k8s.io/test-health)
+- [Test History](https://go.k8s.io/test-history)
+- 
 
 ## Other
 


### PR DESCRIPTION
Firstly, thanks for making this repo, @castrojo! I find myself referring it many times. :)

This PR contains the following changes: 

* Remove reviewable.k8s.io since Reviewable has been disabled for all Kubernetes repos and the link https://reviewable.kubernetes.io/ doesn't work. Ref: the [email](https://groups.google.com/d/msg/kubernetes-dev/0RhWYvxW2XI/U8nfjKfYBQAJ) on kubernetes-dev and https://github.com/kubernetes/k8s.io/pull/124.
* Add links for GitHub labels, Test Health and Test History.
* Update to use short *k8s.io URLs for some links.